### PR TITLE
play: Update to version 0.55

### DIFF
--- a/bucket/play.json
+++ b/bucket/play.json
@@ -1,17 +1,38 @@
 {
-    "version": "0.34",
+    "version": "0.55",
     "description": "A newer experimental ps2 emulator.",
     "homepage": "https://purei.org",
-    "license": {"identifier": "Unknown"},
-    "url": "https://s3.us-east-2.amazonaws.com/playbuilds/940b0235/Play-x86-64.exe",
-    "hash": "24a5fe11fd9b3871d568c20f036a6f153d5b95b4e9e16c9c55810ce2d2757e9c",
-    "notes": "Needs to be install until I figure out how to do otherwise",
-    "bin": "Play-x86-64.exe",
+    "license": "BSD-2-Clause",
+    "architecture": {
+        "32bit": {
+            "url": "https://purei.org/downloads/play/stable/0.55/Play-x86-32.exe#/dl.7z",
+            "hash": "8dc9862942c8bf4010103bfd9fe169ccbbb3462e9684cfa2aebbca3903657fd9"
+        },
+        "64bit": {
+            "url": "https://purei.org/downloads/play/stable/0.55/Play-x86-64.exe#/dl.7z",
+            "hash": "8f47360c91c25066651a3811b4238897150e5d264d4d65368fbd707f76a3f17c"
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall.exe\" -Recurse -Force",
+    "bin": "Play.exe",
     "shortcuts": [
         [
-            "Play-x86-64.exe",
-            "play",
-            "play.exe"
+            "Play.exe",
+            "Play"
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "https://purei.org/downloads/play/stable/?C=M;O=D",
+        "regex": ">([\\d.]+)/<"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://purei.org/downloads/play/stable/$version/Play-x86-32.exe#/dl.7z"
+            },
+            "64bit": {
+                "url": "https://purei.org/downloads/play/stable/$version/Play-x86-64.exe#/dl.7z"
+            }
+        }
+    }
 }


### PR DESCRIPTION
- checkver
- autoupdate
- selfextract

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that will follow the contribution guidelines. You agree to submit a fully featured working manifest that creates shortcuts, bin shims, persists data, enable portable mode, and auto updates.
-->

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [x] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [ ] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [x] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [ ] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [x] license identifier and url
> - [ ] a short terse description matching existing style.
> - [x] url to the release along with its sha256 hash
> - [ ] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [x] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [x] tested install, checked persist, no errors.
> - [x] manifest is sorted to spec
> - [ ] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [ ] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [ ] I will maintain this manifest and promptly fix it in the event it breaks.
