### PR TITLE
vice: Update to version 3.6.2-42517

### DIFF
--- a/bucket/vice.json
+++ b/bucket/vice.json
@@ -1,11 +1,11 @@
 {
-    "version": "42487",
+    "version": "3.6.2-42517",
     "description": "Updated builds of the VICE emulator",
     "homepage": "https://github.com/Zibri/VICE",
     "license": "GPL-2.0",
-    "url": "https://github.com/Zibri/VICE/releases/download/r42487/GTK3VICE-3.6.2-dev-win64-r42487.7z",
-    "hash": "3db7c3ae2808aa737f8646712486d9d0de1338e9459a27e99be0553d471665ec",
-    "extract_dir": "GTK3VICE-3.6.2-dev-win64-r42487",
+    "url": "https://github.com/Zibri/VICE/releases/download/r42517/GTK3VICE-3.6.2-dev-win64-r42517.7z",
+    "hash": "4f1df54b34ef05997daa03b017ba0a96c3fe337f3e00fcd8a8f1f2c8c629b437",
+    "extract_dir": "GTK3VICE-3.6.2-dev-win64-r42517",
     "bin": [
         "bin\\c1541.exe",
         "bin\\cartconv.exe",
@@ -24,10 +24,11 @@
     ],
     "checkver": {
         "github": "https://github.com/Zibri/VICE",
-        "re": "\\/releases\\/tag\\/r([0-9]+)"
+        "regex": "GTK3VICE-(?<release>[\\d.]+)-dev-win64-r(?<build>[\\d]+).7z",
+        "replace": "${release}-${build}"
     },
     "autoupdate": {
-        "url": "https://github.com/Zibri/VICE/releases/download/r42487/GTK3VICE-3.6.2-dev-win64-r$version.7z",
-        "extract_dir": "GTK3VICE-3.6.2-dev-win64-r$version"
+        "url": "https://github.com/Zibri/VICE/releases/download/r$matchBuild/GTK3VICE-$matchRelease-dev-win64-r$matchBuild.7z",
+        "extract_dir": "GTK3VICE-$matchRelease-dev-win64-r$matchBuild"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that will follow the contribution guidelines. You agree to submit a fully featured working manifest that creates shortcuts, bin shims, persists data, enable portable mode, and auto updates.
-->

## What package release type is this?

> - [x] stable
> - [ ] beta
> - [ ] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).
> - [ ] properly named and capitalized shortcuts?
> - [x] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [ ] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [ ] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [ ] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [ ] license identifier and url
> - [ ] a short terse description matching existing style.
> - [ ] url to the release along with its sha256 hash
> - [ ] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [ ] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [ ] tested install, checked persist, no errors.
> - [ ] manifest is sorted to spec
> - [ ] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [ ] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [ ] I will maintain this manifest and promptly fix it in the event it breaks.
