### PR TITLE
medgui-reborn: Update to version 0.120

### DIFF
--- a/bucket/medgui-reborn.json
+++ b/bucket/medgui-reborn.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.119",
+    "version": "0.120",
     "description": "Frontend and launcher for Mednafen multi emulator",
     "homepage": "https://github.com/Speedvicio/MedGuiReborn",
     "license": "CC0-1.0",
-    "url": "https://github.com/Speedvicio/MedGuiReborn/releases/download/v0.119/MedGui.Reborn.v0.119.full.zip",
-    "hash": "a63f1b4a20b1abf545b047151b338fb871f5da2c1b2ee9d12e9044f773ceeff9",
+    "url": "https://github.com/Speedvicio/MedGuiReborn/releases/download/v.0120/MedGui.Reborn.v0.120.full.zip",
+    "hash": "969aea8923d6ac3c4937229c8da4f581748fab063d66d512ee96af3126f58557",
     "extract_dir": "MedGui Reborn",
     "bin": "MedGuiR.exe",
     "shortcuts": [


### PR DESCRIPTION
Autoupdate failed because dev uses v.0120 instead of v0.120 as release tag.
Didn't fix the `checkver` because most of the releases are named correct