### PR TITLE
cscp: update binary hash

### DIFF
--- a/bucket/c/cscp.json
+++ b/bucket/c/cscp.json
@@ -4,7 +4,7 @@
     "homepage": "http://takeda-toshiya.my.coocan.jp/common/index.html",
     "license": "Unknown",
     "url": "http://takeda-toshiya.my.coocan.jp/common/binary.7z",
-    "hash": "efcfe8e9e884c9ee5cfb5fe6d777d10d41996a699acd49d3a85126e23f289728",
+    "hash": "9c0ecebc187d25b7c841f222b2057625ff6286abaf954adc85fe15cd8f778ff5",
     "bin": [
         "babbage2nd.exe",
         "bmjr.exe",


### PR DESCRIPTION
## Summary
- Update the cscp manifest hash for the current binary.7z download.

## Why
The existing hash no longer matches the upstream archive reported in #41.

## Validation
- Downloaded http://takeda-toshiya.my.coocan.jp/common/binary.7z
- Confirmed first bytes: 37 7A BC AF 27 1C 00 04
- Confirmed SHA256: 9c0ecebc187d25b7c841f222b2057625ff6286abaf954adc85fe15cd8f778ff5
- Parsed bucket/c/cscp.json as JSON
- Ran git diff --check