### PR TITLE
Update download URLs for 32bit and 64bit builds

### DIFF
--- a/bucket/f/fbneo-dev.json
+++ b/bucket/f/fbneo-dev.json
@@ -5,7 +5,7 @@
     "license": "https://github.com/finalburnneo/FBNeo/blob/master/src/license.txt",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/finalburnneo/FBNeo/releases/download/latest/Windows.x32.zip",
+            "url": "https://github.com/finalburnneo/FBNeo/releases/download/latest/windows-x86_32.zip",
             "hash": "87cff4fcb4d196203130b543e931e99064fad3b7cd5122a6af57a80754c5365f",
             "bin": [
                 [
@@ -21,7 +21,7 @@
             ]
         },
         "64bit": {
-            "url": "https://github.com/finalburnneo/FBNeo/releases/download/latest/Windows.x64.zip",
+            "url": "https://github.com/finalburnneo/FBNeo/releases/download/latest/windows-x86_64.zip",
             "hash": "6776eb1541f3510f571551809a0afbb3e7ea9556a91be2ecbb4997ef4e6df382",
             "bin": [
                 [


### PR DESCRIPTION
https://github.com/detain/scoop-emulators/issues/56

<!-- Provide a general summary of your changes in the title above -->

update download url(s)

<!--
  By opening this PR you confirm that will follow the contribution guidelines. You agree to submit a fully featured working manifest that creates shortcuts, bin shims, persists data, enable portable mode, and auto updates.
-->

## What package release type is this?

> - [] stable
> - [ ] beta
> - [x] dev/nightly/canary

## I followed the bucket's manifest standards?
> - [x] I have read the [Contributing Guide](../CONTRIBUTING.md).

rest  are n/a

> - [ ] properly named and capitalized shortcuts?
> - [ ] autoupdate and checkver entry [](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate)
> - [ ] [persist](https://github.com/ScoopInstaller/Scoop/wiki/Persistent-data) defined with config/data/user/portable/textures/saves folder(s) specific for the app?
> - [ ] a [pre_install](https://github.com/ScoopInstaller/Scoop/wiki/Pre--and-Post-install-scripts) script to auto-enable portable mode (if needed)?
>   - [ ] a pre_install script creates runtime created files specified in persist (ensures symlinks properly get created)
> - [ ] license identifier and url
> - [ ] a short terse description matching existing style.
> - [ ] url to the release along with its sha256 hash
> - [ ] bin entry for main binary
>     - [ ] if beta, dev, etc: does bin shim have variant appended to the name? (e.g appname-dev)
> - [ ] passes `bin/checkver.ps1` and `bin/checkurls.ps1`
> - [ ] tested install, checked persist, no errors.
> - [ ] manifest is sorted to spec
> - [ ] manifest follows spec: appname or appname-variant (e.g citra-canary or dolphin-dev)
> - [ ] I tested the package and it runs in portable mode. I have verified the symlinks are correct in the persist folder and working.
> - [ ] I will maintain this manifest and promptly fix it in the event it breaks.
